### PR TITLE
fix: repair the build, then take the three dependency updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ serde_ini = "0.2.0"
 serde_json = "1.0.117"
 serde_yml = "0.0.13"
 tempfile = "3.10.1"
-toml = "0.8.13"
+toml = "1.1.4"
 uuid = { version = "1.15", features = ["v4"] }
 vrd = "0.0.12"
 commons = { package = "euxis-commons", git = "https://github.com/sebastienrousseau/commons", tag = "v0.0.3", default-features = false, features = ["error", "config", "logging", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ commons = { package = "euxis-commons", git = "https://github.com/sebastienrousse
 
 [dev-dependencies]
 # The dev-dependencies of the package.
-criterion = "0.5.1"
+criterion = "0.8.2"
 predicates = "3.1.0"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ deprecated_in_future = "deny"
 ellipsis_inclusive_range_patterns = "deny"
 explicit_outlives_requirements = "deny"
 future_incompatible = { level = "deny", priority = -1 }
-keyword_idents = "deny"
+keyword_idents = { level = "deny", priority = -1 }
 macro_use_extern_crate = "deny"
 meta_variable_misuse = "deny"
 missing_fragment_specifier = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ serde_yml = "0.0.13"
 tempfile = "3.10.1"
 toml = "0.8.13"
 uuid = { version = "1.15", features = ["v4"] }
-vrd = "0.0.7"
+vrd = "0.0.12"
 commons = { package = "euxis-commons", git = "https://github.com/sebastienrousseau/commons", tag = "v0.0.3", default-features = false, features = ["error", "config", "logging", "env"] }
 
 [dev-dependencies]

--- a/src/generators/ascii.rs
+++ b/src/generators/ascii.rs
@@ -6,9 +6,9 @@
 //! This module provides functionality for generating ASCII art from text using the FIGlet library.
 
 use crate::models::error_ascii_art::AsciiArtError;
-use figlet_rs::FIGfont;
+use figlet_rs::FIGlet;
 
-/// Generates ASCII art from the given text using the standard `FIGfont`.
+/// Generates ASCII art from the given text using the standard `FIGlet`.
 ///
 /// # Arguments
 ///
@@ -19,7 +19,7 @@ use figlet_rs::FIGfont;
 /// This function returns an `Err` in the following situations:
 ///
 /// - If the input `text` is empty (`ConversionError`).
-/// - If the standard `FIGfont` fails to load (`FontLoadError`).
+/// - If the standard `FIGlet` fails to load (`FontLoadError`).
 /// - If the text cannot be converted to ASCII art (`ConversionError`).
 ///
 /// # Examples
@@ -44,11 +44,11 @@ pub fn generate_ascii_art(text: &str) -> Result<String, AsciiArtError> {
     Ok(figure.to_string())
 }
 
-/// Loads the standard FIGfont.
+/// Loads the standard FIGlet.
 ///
 /// # Errors
 ///
-/// This function returns an `Err` if the standard `FIGfont` fails to load (`FontLoadError`).
+/// This function returns an `Err` if the standard `FIGlet` fails to load (`FontLoadError`).
 ///
 /// # Examples
 ///
@@ -58,6 +58,6 @@ pub fn generate_ascii_art(text: &str) -> Result<String, AsciiArtError> {
 /// let result = load_standard_font();
 /// assert!(result.is_ok());
 /// ```
-pub fn load_standard_font() -> Result<FIGfont, AsciiArtError> {
-    FIGfont::standard().map_err(|_| AsciiArtError::FontLoadError)
+pub fn load_standard_font() -> Result<FIGlet, AsciiArtError> {
+    FIGlet::standard().map_err(|_| AsciiArtError::FontLoadError)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,6 @@
 //! [0]: https://minifunctions.com/libmake "Mini Functions"
 //!
 #![allow(clippy::must_use_candidate)]
-#![cfg_attr(feature = "bench", feature(test))]
 #![deny(dead_code)]
 #![deny(rustc::existing_doc_keyword)]
 #![doc(
@@ -81,9 +80,8 @@
 // Import necessary dependencies
 use crate::args::process_arguments;
 use crate::cli::build;
-use crate::utilities::uuid::generate_unique_string;
 use dtt::DateTime;
-use rlg::{log_format::LogFormat, log_level::LogLevel, macro_log};
+use rlg::{Log, LogFormat, LogLevel};
 use std::{error::Error, fs::File, io::Write};
 
 /// The `args` module contains functions for processing command-line
@@ -124,34 +122,38 @@ pub mod utilities;
 ///
 pub fn run() -> Result<(), Box<dyn Error>> {
     let date = DateTime::new();
-    let iso = date.iso_8601;
+    // dtt 0.0.11 made the struct fields pub(crate); the public
+    // accessor is format_rfc3339(), which is ISO 8601 compatible.
+    let iso = date.format_rfc3339()?;
 
     // Open the log file for appending
     let mut log_file = File::create("./libmake.log")?;
 
     // Generate ASCII art for the tool's CLI
-    let log = macro_log!(
-        &generate_unique_string(),
-        &iso,
-        &LogLevel::INFO,
-        "deps",
-        "ASCII art generation event started.",
-        &LogFormat::CLF
-    );
+    let log = Log {
+        format: LogFormat::CLF,
+        ..Log::build(
+            LogLevel::INFO,
+            "ASCII art generation event started.",
+        )
+        .time(&iso)
+        .component("deps")
+    };
     // Write the log to both the console and the file
     writeln!(log_file, "{}", log)?;
 
     // Printing the ASCII art to the console
     println!("{}", macro_ascii!("LibMake"));
 
-    let log = macro_log!(
-        &generate_unique_string(),
-        &iso,
-        &LogLevel::INFO,
-        "deps",
-        "ASCII art generation event completed.",
-        &LogFormat::CLF
-    );
+    let log = Log {
+        format: LogFormat::CLF,
+        ..Log::build(
+            LogLevel::INFO,
+            "ASCII art generation event completed.",
+        )
+        .time(&iso)
+        .component("deps")
+    };
     // Write the log to both the console and the file
     writeln!(log_file, "{}", log)?;
 
@@ -160,14 +162,19 @@ pub fn run() -> Result<(), Box<dyn Error>> {
     process_arguments(&matches)?;
 
     // Check the number of arguments, provide a welcome message if no arguments were passed
-    macro_log!(
-        &generate_unique_string(),
-        &iso,
-        &LogLevel::INFO,
-        "cli",
-        "Welcome to LibMake! 👋\n\nLet's get started! Please, run `libmake --help` for more information.",
-        &LogFormat::CLF
-    );
+    // The old `macro_log!` emitted as a side effect; `Log::build` only
+    // constructs, so this entry has to be emitted explicitly or it is
+    // silently dropped.
+    Log {
+        format: LogFormat::CLF,
+        ..Log::build(
+            LogLevel::INFO,
+            "Welcome to LibMake! 👋\n\nLet's get started! Please, run `libmake --help` for more information.",
+        )
+        .time(&iso)
+        .component("cli")
+    }
+    .log();
     eprintln!(
         "\n\nWelcome to LibMake! 👋\n\nLet's get started! Please, run `libmake --help` for more information.\n"
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,6 @@ use libmake::run;
 ///
 /// # License
 /// This code is dual-licensed under the Apache License 2.0 and the MIT License.
-
 fn main() {
     // Call the `run()` function from the `LibMake (LM)` module.
     if let Err(err) = run() {

--- a/src/models/model_params.rs
+++ b/src/models/model_params.rs
@@ -110,9 +110,6 @@ impl FileGenerationParams {
             website: Some("https://example.com/john-smith".to_string()),
         }
     }
-    /// Parses the command line arguments and returns a new instance of
-    /// the structure.
-
     /// Creates a new instance with default values.
     pub fn new() -> Self {
         Self::default_params()

--- a/src/utilities/directory.rs
+++ b/src/utilities/directory.rs
@@ -109,7 +109,7 @@ pub fn move_output_directory(
 /// # Arguments
 ///
 /// * `directories` - An array of references to `Path` objects representing the
-///    directories to be cleaned up.
+///   directories to be cleaned up.
 ///
 /// # Returns
 ///
@@ -142,7 +142,7 @@ pub fn cleanup_directory(
 /// # Arguments
 ///
 /// * `directories` - An array of references to `Path` objects representing the
-///    directories to be created.
+///   directories to be created.
 ///
 /// # Returns
 ///

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,12 +54,8 @@ pub fn get_csv_field(
         let mut values = Vec::new();
         for result in rdr.records() {
             let record = result.ok()?;
-            if let Some(field_value) = record.get(field_index) {
-                values.push(field_value.to_string());
-            } else {
-                // Field index is out of range
-                return None;
-            }
+            // `?` propagates the out-of-range field index as None.
+            values.push(record.get(field_index)?.to_string());
         }
         if values.is_empty() {
             None

--- a/tests/macros/test_ascii_macros.rs
+++ b/tests/macros/test_ascii_macros.rs
@@ -5,7 +5,9 @@ mod tests {
     #[test]
     fn test_macro_ascii_success() {
         let art = macro_ascii!("Hi");
-        assert_eq!(art, "  _   _   _ \n | | | | (_)\n | |_| | | |\n |  _  | | |\n |_| |_| |_|\n            \n");
+        // figlet-rs 1.0.0 kerns more tightly than 0.1.x: the leading
+        // column of padding each glyph used to carry is gone.
+        assert_eq!(art, " _   _ _ \n| | | (_)\n| |_| | |\n|  _  | |\n|_| |_|_|\n         \n");
     }
 
     #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,3 +1,5 @@
+//! Integration-test crate root: declares the test modules below.
+
 /// This module contains the tests for the `macros` module.
 pub mod macros;
 

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1,3 +1,5 @@
+//! Integration tests: test cli.
+
 #[cfg(test)]
 mod tests {
     use libmake::cli::{build, create_arg};

--- a/tests/test_generator.rs
+++ b/tests/test_generator.rs
@@ -1,3 +1,5 @@
+//! Integration tests: test generator.
+
 use libmake::{
     generator::generate_from_config,
     generators::{args::generate_from_args, yaml::generate_from_yaml},

--- a/tests/test_interface.rs
+++ b/tests/test_interface.rs
@@ -1,3 +1,5 @@
+//! Integration tests for the public `libmake` interface.
+
 #[cfg(test)]
 mod tests {
     use libmake::{

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -1,3 +1,5 @@
+//! Integration tests: test utils.
+
 #[cfg(test)]
 mod tests {
 


### PR DESCRIPTION
Supersedes #47, #48 and #49.

**`libmake` did not compile.** Not "failed a lint" — `cargo check` could not produce a library. The three dependency pull requests were never at fault; they simply could not be verified, and each also conflicts with the others on `Cargo.toml`.

## Four API drifts, each hidden behind the previous one

| dependency | what changed |
|---|---|
| `figlet-rs` 1.0.0 | `FIGfont` renamed to **`FIGlet`** — same `standard()` / `convert()`, pure rename |
| `dtt` 0.0.11 | `DateTime` fields became `pub(crate)`; the public accessor is `format_rfc3339()` (ISO 8601 compatible) |
| `rlg` 0.0.11 | **`macro_log!` no longer exists** — replaced by `Log::build(level, desc).time(..).component(..)` |
| `Cargo.toml` | `keyword_idents` is a lint **group** in current Rust and needs `priority = -1` — the same treatment `future_incompatible` already has two lines above it |

Only after all four did **clippy run at all**, and it then found six further issues that had never been reachable on this machine.

## Clippy caught a bug I had just introduced

The third `macro_log!` site had no `let` binding. The old macro emitted as a side effect; `Log::build` only *constructs*. My rewrite therefore built a log entry and silently dropped it — a real behavioural regression, invisible to the tests. It is now emitted with `.log()`.

## One rename reverted

The blanket `FIGfont` → `FIGlet` pass also rewrote a **user-facing error string** to `"Failed to load FIGlet"`. That is wrong: **FIGfont is the name of the font file format** (`.flf`), not of the renamed Rust type. `src/models/error_ascii_art.rs` is left untouched.

## `feature(test)` removed, not declared

`#![cfg_attr(feature = "bench", feature(test))]` referenced an undeclared feature. Declaring it would have made `--all-features` require **nightly**. The bench target sets `harness = false` and uses criterion, so the built-in test harness is never involved — the attribute is vestigial and is removed.

## Verification

| gate | result |
|---|---|
| `cargo check --all-targets` | exit 0 |
| `cargo clippy --all-targets --all-features -- -D warnings` | exit 0 |
| `cargo fmt -- --check` | exit 0 |
| `cargo test --all-features` | **75 passed, 0 failed** |
| `cargo bench --no-run` | exit 0 |

The ASCII-art expectation moved with figlet-rs 1.0.0, which kerns more tightly than 0.1.x — the old expected string carried a leading pad column the new renderer does not emit.