### PR TITLE
chore(deps): replace deprecated serde_yml with noyalib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ rlg = "0.0.11"
 serde = { version = "1.0.202", features = ["derive"] }
 serde_ini = "0.2.0"
 serde_json = "1.0.117"
-serde_yml = "0.0.13"
+noyalib = { version = "0.0.27", default-features = false, features = ["std"] }
 tempfile = "3.10.1"
 toml = "1.1.4"
 uuid = { version = "1.15", features = ["v4"] }

--- a/src/generators/yaml.rs
+++ b/src/generators/yaml.rs
@@ -37,7 +37,7 @@ use std::io;
 pub fn generate_from_yaml(path: &str) -> io::Result<()> {
     let contents = fs::read_to_string(path)?;
     let params: FileGenerationParams =
-        serde_yml::from_str(&contents)
+        noyalib::from_str(&contents)
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     macro_generate_files!(params.clone())
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;

--- a/src/generators/yaml.rs
+++ b/src/generators/yaml.rs
@@ -36,9 +36,8 @@ use std::io;
 ///
 pub fn generate_from_yaml(path: &str) -> io::Result<()> {
     let contents = fs::read_to_string(path)?;
-    let params: FileGenerationParams =
-        noyalib::from_str(&contents)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let params: FileGenerationParams = noyalib::from_str(&contents)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     macro_generate_files!(params.clone())
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     Ok(())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -67,7 +67,7 @@ pub fn get_csv_field(
 
 macro_get_field!(get_ini_field, serde_ini::from_read);
 macro_get_field!(get_json_field, serde_json::from_reader);
-macro_get_field!(get_yaml_field, serde_yml::from_reader);
+macro_get_field!(get_yaml_field, noyalib::from_reader);
 
 /// Retrieves a specific field's value from a configuration file.
 ///


### PR DESCRIPTION
`serde_yml` is deprecated and unmaintained. noyalib is a maintained,
serde-compatible YAML implementation exposing the same `from_str` /
`from_reader` surface, so this is a drop-in swap at both call sites:

- `src/utils.rs` — `macro_get_field!(get_yaml_field, noyalib::from_reader)`
- `src/generators/yaml.rs` — `noyalib::from_str(&contents)`

Taken with `default-features = false, features = ["std"]`: this crate
needs the core parse path, not the diagnostic renderer.

### Verified

build clean · **35 tests pass**

### One pre-existing failure, not caused by this PR

`tests::test_build_manual_subcommand` fails — **and it fails on
unmodified `main` too.** Checked in a detached worktree off `main`
with none of these changes applied:

```
unmodified-main test_cli exit=101
tests::test_build_manual_subcommand
---- tests::test_build_manual_subcommand stdout ----
assertion failed: matches.is_ok()
```

Identical exit code, identical assertion at `tests/test_cli.rs:10`. The
test calls `cli::build()`, which constructs clap arguments and never
touches YAML. Pre-existing, out of scope for this PR, and not masked by
it — worth its own issue.