### PR TITLE
ci: fix the startup failure that disabled CI entirely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,13 @@ concurrency:
 jobs:
   ci:
     name: Rust CI
-    uses: sebastienrousseau/pipelines/.github/workflows/rust-ci.yml@main
+    uses: sebastienrousseau/pipelines/.github/workflows/rust-ci.yml@89f643dd0adb55bd4c8332fec20be8aa44efad11
     with:
       rust-version: 'stable'
       run-clippy: true
       run-fmt: true
       run-audit: true
       run-coverage: true
-      coverage-threshold: 80
     secrets: inherit
 
   # Nightly toolchain tests (optional, continue on error)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,12 @@ jobs:
       rust-version: 'stable'
       run-clippy: true
       run-fmt: true
-      run-audit: true
+      # The reusable audit uses rustsec/audit-check, which requires a
+      # committed Cargo.lock. This repo gitignores it, so that job can
+      # only ever fail with "Couldn\'t load ./Cargo.lock". The local
+      # cargo-audit job below supersedes it — the CLI generates the
+      # lockfile itself.
+      run-audit: false
       run-coverage: true
     secrets: inherit
 
@@ -46,3 +51,15 @@ jobs:
 
       - name: Run tests
         run: cargo test --all-features
+
+  cargo-audit:
+    name: cargo-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo install --locked cargo-audit
+      # No --deny warnings: unmaintained notices for transitive crates
+      # are not actionable from here. Vulnerabilities still fail the job.
+      - run: cargo audit


### PR DESCRIPTION
**CI here has not been failing — it has not been running.** Every run
reports `startup_failure`, so no job executes and PRs show zero checks.
A PR in this repo can read as green while nothing whatsoever has run.

### Cause

An input the reusable workflow does not declare:

```yaml
uses: sebastienrousseau/pipelines/.github/workflows/rust-ci.yml@main
with:
  coverage-threshold: 80   # <- not a declared input
```

`rust-ci.yml` accepts `cargo-features`, `coverage-exclude`,
`coverage-exclude-packages`, `run-audit`, `run-clippy`, `run-coverage`,
`run-cross-platform`, `run-fmt`, `runner`, `rust-version`,
`timeout-minutes`. Passing anything else is a **hard startup failure** —
the workflow dies before job one. Removing it leaves five valid inputs.

metadata-gen passes only valid inputs, which is why its CI works and
this one never has.

### Also: pinned by SHA

`@main` is now `@89f643dd0adb55bd4c8332fec20be8aa44efad11`, matching
metadata-gen. A moving `@main` lets a third-party workflow change under
this repo without review — the same risk action-pinning addresses, and
worth closing for a workflow invoked with `secrets: inherit`.

### Verification

This PR is its own test: if CI reports actual check runs instead of
`startup_failure`, the fix works. That has not been possible to
demonstrate on any recent PR in this repo.