### PR TITLE
fix(cli): stop build() parsing the test harness's arguments

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,21 +7,45 @@
 
 use clap::{error::Error, Arg, ArgMatches, Command};
 
-/// Constructs the command-line interface for the application using Clap,
-/// including all necessary arguments.
+/// Constructs the command-line interface and parses the arguments this
+/// process was started with.
+///
+/// This is a thin wrapper over [`build_from`] that reads
+/// [`std::env::args_os`]. Prefer [`build_from`] anywhere the arguments
+/// should not depend on how the process was launched — tests and
+/// doctests especially, since there the arguments belong to the test
+/// harness rather than to this CLI.
+///
+/// # Errors
+///
+/// Returns an error if parsing the process arguments fails.
+pub fn build() -> Result<ArgMatches, Error> {
+    build_from(std::env::args_os())
+}
+
+/// Constructs the command-line interface and parses `args`.
+///
+/// `args` follows the usual convention: the first element is the
+/// program name and is ignored for matching purposes.
 ///
 /// # Examples
 ///
 /// ```
 /// use libmake::cli;
-/// let matches = cli::build().expect("CLI parsing failed");
+///
+/// // Deterministic: does not inherit the caller's arguments.
+/// let matches = cli::build_from(["libmake"]).expect("CLI parsing failed");
+/// assert!(matches.subcommand_name().is_none());
 /// ```
 ///
 /// # Errors
 ///
-/// This function will return an error if the command-line argument parsing fails.
-///
-pub fn build() -> Result<ArgMatches, Error> {
+/// Returns an error if the supplied arguments fail to parse.
+pub fn build_from<I, T>(args: I) -> Result<ArgMatches, Error>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<std::ffi::OsString> + Clone,
+{
     let manual_args = vec![
             create_arg_info("author", Some("Me"), "Sets the author of the library", 'a', "author", "AUTHOR"),
             create_arg_info("build", Some("build.rs"), "Sets the build script that is used to perform additional build-time operations.", 'b', "build", "BUILD"),
@@ -101,7 +125,7 @@ pub fn build() -> Result<ArgMatches, Error> {
         );
 
     // Assuming validate_args is a custom function that you have implemented
-    let matches = command.clone().try_get_matches()?;
+    let matches = command.clone().try_get_matches_from(args)?;
 
     Ok(matches)
 }

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -18,7 +18,8 @@ mod tests {
 
     #[test]
     fn test_build_manual_subcommand() {
-        let matches = build_from(["libmake", "manual", "--name", "demo"]);
+        let matches =
+            build_from(["libmake", "manual", "--name", "demo"]);
         assert!(matches.is_ok());
         let matches = matches.unwrap();
         assert_eq!(matches.subcommand_name(), Some("manual"));

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -2,12 +2,46 @@
 
 #[cfg(test)]
 mod tests {
-    use libmake::cli::{build, create_arg};
+    use libmake::cli::{build_from, create_arg};
+
+    // These use `build_from` rather than `build`. `build` parses
+    // `std::env::args_os()`, which inside a test binary belongs to the
+    // test harness — so `cargo test -- --nocapture` made clap reject
+    // `--nocapture` and this assertion failed, even though nothing about
+    // the CLI had changed.
+    #[test]
+    fn test_build_no_subcommand() {
+        let matches = build_from(["libmake"]);
+        assert!(matches.is_ok());
+        assert!(matches.unwrap().subcommand_name().is_none());
+    }
 
     #[test]
     fn test_build_manual_subcommand() {
-        let matches = build();
+        let matches = build_from(["libmake", "manual", "--name", "demo"]);
         assert!(matches.is_ok());
+        let matches = matches.unwrap();
+        assert_eq!(matches.subcommand_name(), Some("manual"));
+        let sub = matches.subcommand_matches("manual").unwrap();
+        assert_eq!(
+            sub.get_one::<String>("name").map(String::as_str),
+            Some("demo")
+        );
+    }
+
+    #[test]
+    fn test_build_file_subcommand() {
+        let matches =
+            build_from(["libmake", "file", "--toml", "cfg.toml"]);
+        assert!(matches.is_ok());
+        assert_eq!(matches.unwrap().subcommand_name(), Some("file"));
+    }
+
+    #[test]
+    fn test_build_rejects_unknown_argument() {
+        // The exact shape that broke the suite under `--nocapture`.
+        let matches = build_from(["libmake", "--nocapture"]);
+        assert!(matches.is_err());
     }
 
     #[test]


### PR DESCRIPTION
`cargo test -- --nocapture` — an entirely ordinary command — fails:

```
thread 'tests::test_build_manual_subcommand' panicked at tests/test_cli.rs:10:9:
assertion failed: matches.is_ok()
```

### Cause

`build()` ends in `command.try_get_matches()`, which parses
`std::env::args_os()`. Inside a test binary those arguments belong to
the **test harness**, so clap sees `--nocapture`, rejects it as an
unknown argument, and the assertion fails — with nothing about the CLI
having changed.

The test passed only because cargo passes no extra arguments by
default. Any `cargo test -- <flag>` breaks it.

### Fix

Adds `build_from(args)`, parsing an explicit argument list.
`build()` delegates to it with `std::env::args_os()`, so its signature
and behaviour are unchanged for callers — **additive, not breaking**.

### The tests now actually assert something

The old test called `build()` and checked `is_ok()`. Under a bare argv
that only proved clap had constructed the command without panicking — it
never parsed a subcommand or an argument value.

| test | asserts |
|---|---|
| `test_build_no_subcommand` | bare invocation yields no subcommand |
| `test_build_manual_subcommand` | `manual --name demo` parses, `name` == `demo` |
| `test_build_file_subcommand` | `file --toml cfg.toml` selects `file` |
| `test_build_rejects_unknown_argument` | `--nocapture` errors — regression guard for this bug |

The `build_from` doctest is deterministic for the same reason: the
previous example called `build()`, inheriting whatever arguments the
doctest binary was launched with.

### Verified

build 0 · clippy `-D warnings` 0 · doctests 0 · **78 tests pass** ·
`cargo test --all-features -- --nocapture` exits **0**

### Note on the separate, already-fixed failure

I had been tracking `test_build_manual_subcommand` as failing on
`main`. That is **no longer true** — `a982aa3` (#50) repaired it, and
the suite is green on current `main`. This PR addresses the different,
still-reproducible `--nocapture` failure described above, not that one.