### PR TITLE
ci(document): fix libssl1.1 install step broken by Ubuntu archive removal

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -24,11 +24,6 @@ jobs:
 
       - uses: actions/checkout@v7
 
-      - name: Update libssl
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libssl1.1
-
       - name: Generate documentation for all features and publish it
         run: |
           RUSTDOCFLAGS="--cfg docsrs" \


### PR DESCRIPTION
libssl1.1 was removed from the Ubuntu archive after 20.04, so
`apt-get install -y libssl1.1` fails on ubuntu-latest and the
Document job never reaches the doc build.

Nothing in the dependency graph links OpenSSL — the lockfile has no
openssl-sys, native-tls or openssl entry — so the step has no purpose
beyond the failure it causes. Verified `cargo doc --no-deps
--all-features --workspace` builds clean without it.


Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)